### PR TITLE
Made Build faster

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -25,6 +25,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Populates Tickers
+      run: |
+        echo "MSFT" > Tickers
     - name: Run the script
       run: |
         python3 companyanalyzer.py


### PR DESCRIPTION
Made sure that the Tickers file will only have one ticker (MSFT) in order to speed things around at build time.

Signed-off-by: Alexandru Nisulescu <alexn@Alexs-MacBook-Pro.local>